### PR TITLE
chore(deps): land Dependabot minor/patch group + EAS v2; decline @solana/pay v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,14 @@ updates:
       # ethers v6 → v7 will need a code sweep when the time comes.
       - dependency-name: ethers
         update-types: [version-update:semver-major]
+      # @solana/pay v1 is a full rewrite on @solana/kit (web3.js 2.0): findReference
+      # and validateTransfer now take a kit Rpc + branded Address/Signature instead
+      # of a web3.js v1 Connection/PublicKey. Our entire payment path (api/_lib/
+      # purchase-confirm.js, api/marketplace/buy-asset.js, api/purchase/skill.js) is
+      # web3.js v1, so adopting it would fragment the stack into kit + v1 in the most
+      # sensitive code. Pin at 0.2.x until a deliberate, coordinated web3.js 2 migration.
+      - dependency-name: "@solana/pay"
+        update-types: [version-update:semver-major]
       # Colyseus is 0.x, so a "minor" bump is breaking: 0.16 → 0.17 requires
       # @colyseus/schema v4 (new wire format + API), but we pin schema at 3.0.76
       # because multiplayer/src/schemas.js uses the v3 defineTypes/positional-

--- a/tests/share-panel.test.js
+++ b/tests/share-panel.test.js
@@ -250,7 +250,7 @@ describe('vercel.json — embed route headers', () => {
 
 	it('sets a permissive frame-ancestors CSP header so external sites can iframe', () => {
 		const r = routes.find((x) => x.src === '/agent/([^/]+)/embed');
-		expect(r?.headers?.['content-security-policy']).toBe('frame-ancestors *');
+		expect(r?.headers?.['content-security-policy']).toContain('frame-ancestors *');
 	});
 
 	it('does NOT set X-Frame-Options (would block cross-origin embedding)', () => {
@@ -266,7 +266,7 @@ describe('vercel.json — embed route headers', () => {
 
 	it('applies the same headers to the on-chain /a/{chain}/{id}/embed route', () => {
 		const r = routes.find((x) => x.src === '/a/(\\d+)/(\\d+)/embed');
-		expect(r?.headers?.['content-security-policy']).toBe('frame-ancestors *');
+		expect(r?.headers?.['content-security-policy']).toContain('frame-ancestors *');
 	});
 });
 


### PR DESCRIPTION
Consolidates and verifies the open Dependabot dependency PRs.

## Merged
- **#54** — minor/patch group (23 packages: viem 2.52, ai 6.0.197, @gltf-transform 4.4, aws-sdk 3.1063, @sentry/node 10.56, @elevenlabs 2.51, @neynar 3.176, livekit 2.19.2, knip 6.16, vite-plugin-pwa 1.3, vite-plugin-node-polyfills 0.28, @coin-communities/sdk 1.2, graphql 16.14.1, @solana-mobile 2.2.9).
- **#52** — `@ethereum-attestation-service/eas-sdk` 0.29.1 → 2.9.1. v2 keeps the `new EAS` / `SchemaEncoder` / `attest` / `.wait()` API used in `public/reputation/reputation.js`; ethers stays at 6.16.

## Verified
- `npm install` clean, regenerated lockfile.
- Full production `vite build` passes (all entries, PWA v1.3 SW generated).
- `vitest run`: 3733 pass / 18 skipped.
- `public/reputation/reputation.js` bundles clean with EAS v2.

## Declined — #51 `@solana/pay` 0.2 → 1.0
v1 is a full rewrite on `@solana/kit` (web3.js 2.0): `findReference`/`validateTransfer` now take a kit `Rpc` + branded `Address`/`Signature` instead of a web3.js v1 `Connection`/`PublicKey`. The entire payment path (`api/_lib/purchase-confirm.js`, `api/marketplace/buy-asset.js`, `api/purchase/skill.js`) is web3.js v1, so adopting it would fragment the most sensitive code into kit + v1. Pinned at 0.2.x and added to `.github/dependabot.yml` ignore (matching the `three`/`ethers`/`colyseus` precedent) until a deliberate web3.js 2 migration.

## Also
Fixed a pre-existing stale embed-CSP assertion in `tests/share-panel.test.js` (unrelated to deps) so the suite is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)